### PR TITLE
Use the selected CRS as subsetting CRS

### DIFF
--- a/simplewcs.py
+++ b/simplewcs.py
@@ -337,7 +337,7 @@ class SimpleWCS:
         subset1 = label1 + '(' + str(coordinates[1]) + ',' + str(coordinates[3]) + ')'
 
         outputcrs = self.dlg.cbCRS.currentText()
-        mapcrs = self.iface.mapCanvas().mapSettings().destinationCrs().authid()
+        mapcrs = self.dlg.cbCRS.currentText()
         format = self.dlg.cbFormat.currentText()
 
         params = [('REQUEST', 'GetCoverage'), ('SERVICE', 'WCS'), ('VERSION', version), ('COVERAGEID', covId), ('OUTPUTCRS', outputcrs), ('SUBSETTINGCRS', mapcrs), ('FORMAT', format), ('SUBSET', subset0), ('SUBSET', subset1)]


### PR DESCRIPTION
Here's one solution to https://github.com/marcusmohr/simplewcs2/issues/8.
This is based on the assumption that the user would always select a CRS in the dialog that is equal to the current canvas CRS. This might not be the case.