### PR TITLE
Add support for WCS with authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 pb_tool.cfg
 resources.py
+.vscode

--- a/capabilities.py
+++ b/capabilities.py
@@ -134,12 +134,12 @@ class Capabilities:
         if operationsMetadataElement:
             try:
                 self._describeCoverageUrl = operationsMetadataElement.find(f'{ows_ns}Operation[@name="DescribeCoverage"]/{ows_ns}DCP/{ows_ns}HTTP/{ows_ns}Get').attrib.get(f'{xlink_ns}href')
-            except:
+            except Exception:
                 logWarnMessage('Error in getCapabilities response: Missing describeCoverage url in <OperationsMetadata>')
                 self._describeCoverageUrl = ''
             try:
                 self._getCoverageUrl = operationsMetadataElement.find(f'{ows_ns}Operation[@name="GetCoverage"]/{ows_ns}DCP/{ows_ns}HTTP/{ows_ns}Get').attrib.get(f'{xlink_ns}href')
-            except:
+            except Exception:
                 logWarnMessage('Error in getCapabilities response: Missing getCoverage url in OperationsMetadata')
                 self._getCoverageUrl = ''
         else:

--- a/capabilities.py
+++ b/capabilities.py
@@ -131,7 +131,7 @@ class Capabilities:
     def __initializeFromCapabilitiesResponse(self, capabilitiesXmlResponse: xml.etree.ElementTree) -> None:
 
         operationsMetadataElement = capabilitiesXmlResponse.find(f'{ows_ns}OperationsMetadata')
-        if operationsMetadataElement:
+        if operationsMetadataElement is not None:
             try:
                 self._describeCoverageUrl = operationsMetadataElement.find(f'{ows_ns}Operation[@name="DescribeCoverage"]/{ows_ns}DCP/{ows_ns}HTTP/{ows_ns}Get').attrib.get(f'{xlink_ns}href')
             except Exception:

--- a/coverage.py
+++ b/coverage.py
@@ -7,7 +7,7 @@
         licence: GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007
 """
 from dataclasses import dataclass
-from typing import List, Dict, Optional
+from typing import List, Dict
 import xml.etree.ElementTree
 
 from .helpers import logWarnMessage
@@ -28,7 +28,7 @@ class DescribeCoverage:
 
     def __init__(self, coverageXmlResponse: xml.etree.ElementTree) -> None:
 
-        self.coverageInformation: Optional[Dict[str, CoverageInformation]] = None
+        self.coverageInformation: Dict[str, CoverageInformation] | None = None
 
         self.readDescribeCoverage(coverageXmlResponse)
 

--- a/simplewcs.py
+++ b/simplewcs.py
@@ -11,7 +11,6 @@
 """
 
 import os.path
-from typing import Optional
 
 from qgis.PyQt.QtCore import (QCoreApplication,
                               QSettings,
@@ -44,7 +43,7 @@ class SimpleWCS:
             self.translator.load(locale_path)
             QCoreApplication.installTranslator(self.translator)
 
-        self.dlg: Optional[SimpleWCSDialog] = None
+        self.dlg: SimpleWCSDialog | None = None
 
     def tr(self, message) -> str:
         """ Returns a translated string. """

--- a/simplewcs_dialog.py
+++ b/simplewcs_dialog.py
@@ -755,7 +755,7 @@ class SimpleWCSDialog(BASE, GENERATED_CLASS):
             if capabilitiesXmlMainTag != f'{wcs_ns}Capabilities':
                 raise CapabilitiesException('Error: Could not read capabilities for this service')
             capabilitiesXml = ET.ElementTree(ET.fromstring(capabilitiesStr)) # nosec
-        except:
+        except Exception:
             raise CapabilitiesException('Error: Could not read capabilities for this service')
 
         return capabilitiesXml
@@ -787,7 +787,7 @@ class SimpleWCSDialog(BASE, GENERATED_CLASS):
             if coverageXmlMainTag != f'{wcs_ns}CoverageDescriptions':
                 raise DescribeCoverageException('Error: Could not read describeCoverage for this service')
             describeCoverageXml = ET.ElementTree(ET.fromstring(coverageStr)) # nosec
-        except:
+        except Exception:
             raise DescribeCoverageException('Error: Could not read describeCoverage for this service')
 
         return describeCoverageXml
@@ -861,7 +861,7 @@ class SimpleWCSDialog(BASE, GENERATED_CLASS):
                     y_1 = float(y_1)
                     x_2 = float(x_2)
                     y_2 = float(y_2)
-                except:
+                except Exception:
                     warningMessage = 'No bounding box available for this coverage'
                     self.writeToPluginMessageBar(warningMessage)
                     logWarnMessage(warningMessage)
@@ -1161,7 +1161,7 @@ def getCoverage(task, urlGetCoverage: str, covId: str, authcfg: str = '') -> dic
         logWarnMessage(str(e))
         logWarnMessage(str(e.read().decode()))
         return None
-    except:
+    except Exception:
         return None
     try:
         replyString = bytes(replyContent).decode()
@@ -1169,7 +1169,7 @@ def getCoverage(task, urlGetCoverage: str, covId: str, authcfg: str = '') -> dic
         coverageXmlMainTag = root.tag
         if 'ExceptionReport' in coverageXmlMainTag:
             return None
-    except:
+    except Exception:
         return {'file': replyContent, 'coverage': covId}
 
 

--- a/simplewcs_dialog.py
+++ b/simplewcs_dialog.py
@@ -959,7 +959,7 @@ class SimpleWCSDialog(BASE, GENERATED_CLASS):
         else:
             axisList = getAxisLabels(subsetCrsUri)
             if not axisList:
-                logInfoMessage(f"Axis labels of subset crs could not be found. Native crs is used as subset crs instead.")
+                logInfoMessage("Axis labels of subset crs could not be found. Native crs is used as subset crs instead.")
                 axisLabel0, axisLabel1 = self.describeCov.coverageInformation[covId].axisLabels
                 subsetCrsUri = nativeCrsUri
             elif len(axisList) > 2:

--- a/simplewcs_dialog.py
+++ b/simplewcs_dialog.py
@@ -140,9 +140,15 @@ class SimpleWCSDialog(BASE, GENERATED_CLASS):
         """
         Sets up the QGIS QgsAuthSettingsWidget, used for managing authentications.
         """
-        authcfg = self.get_auth_configID()
-        self.auth_gui = QgsAuthSettingsWidget(self.serviceAuth, configId = authcfg, dataprovider = 'wcs')
+        # Type annotation to use type check features of IDEs
+        self.auth_gui: QgsAuthSettingsWidget
+        
+        # remove Basic Auth Tab so only the auth configID matters
         self.auth_gui.removeBasicSettings()
+
+        authcfg = self.get_auth_configID()
+        self.auth_gui.setConfigId(authcfg)
+        
 
     def get_auth_configID(self, service_index: int | None = None) -> str:
         """returns the auth configID of the service with the given index. If none is given,

--- a/simplewcs_dialog.py
+++ b/simplewcs_dialog.py
@@ -146,25 +146,6 @@ class SimpleWCSDialog(BASE, GENERATED_CLASS):
         # remove Basic Auth Tab so only the auth configID matters
         self.auth_gui.removeBasicSettings()
 
-        authcfg = self.get_auth_configID()
-        self.auth_gui.setConfigId(authcfg)
-        
-
-    def get_auth_configID(self, service_index: int | None = None) -> str:
-        """returns the auth configID of the service with the given index. If none is given,
-        the configID of the currently selected service is returned.
-
-        Args:
-            service_index (int | None, optional): Index of the saved Service configuration. Defaults to None.
-
-        Returns:
-            str: configID of the authentication cofiguration of the QGIS Authentication Framework.
-        """
-        if not service_index:
-            service_index = self.getSelectedSavedServiceIndex()
-        authcfg = self.savedServices[service_index].get('authcfg','') if isinstance(service_index, int) else ''
-        return authcfg
-
     def setupGetCoverageTab(self) -> None:
         """
         Sets up "Get Coverage" Tab:

--- a/simplewcs_dialog.py
+++ b/simplewcs_dialog.py
@@ -10,7 +10,7 @@ import os
 import json
 import urllib
 import xml.etree.ElementTree as ET # nosec
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 from urllib.error import HTTPError, URLError
 
 from qgis.PyQt.QtCore import (Qt,
@@ -71,24 +71,24 @@ class SimpleWCSDialog(BASE, GENERATED_CLASS):
         super().__init__(iface.mainWindow())
 
         # Subset coordinates (polygon mode)
-        self.requestXMinPolygon: Optional[float] = None
-        self.requestYMinPolygon: Optional[float] = None
-        self.requestXMaxPolygon: Optional[float] = None
-        self.requestYMaxPolygon: Optional[float] = None
+        self.requestXMinPolygon: float | None = None
+        self.requestYMinPolygon: float | None = None
+        self.requestXMaxPolygon: float | None = None
+        self.requestYMaxPolygon: float | None = None
 
         # Subset coordinates (canvas mode)
-        self.requestXMinCanvas: Optional[float] = None
-        self.requestYMinCanvas: Optional[float] = None
-        self.requestXMaxCanvas: Optional[float] = None
-        self.requestYMaxCanvas: Optional[float] = None
+        self.requestXMinCanvas: float | None = None
+        self.requestYMinCanvas: float | None = None
+        self.requestXMaxCanvas: float | None = None
+        self.requestYMaxCanvas: float | None = None
 
-        self.coverageBoundingBox: Optional[BoundingBox] = None
-        self.subsetBoundingBox: Optional[BoundingBox] = None
+        self.coverageBoundingBox: BoundingBox | None = None
+        self.subsetBoundingBox: BoundingBox | None = None
 
-        self.capabilities: Optional[Capabilities] = None
-        self.describeCov: Optional[DescribeCoverage] = None
+        self.capabilities: Capabilities | None = None
+        self.describeCov: DescribeCoverage | None = None
 
-        self.sketchingToolAction: Optional[QAction] = None
+        self.sketchingToolAction: QAction | None = None
 
         self.mapCrs: str = self.getMapCrs()
 
@@ -209,10 +209,10 @@ class SimpleWCSDialog(BASE, GENERATED_CLASS):
             return serviceName
         return f"{service['url']} [{service['version']}]"
 
-    def getSelectedSavedServiceIndex(self) -> Optional[int]:
+    def getSelectedSavedServiceIndex(self) -> int | None:
         return self.cbSavedServices.currentData()
 
-    def normalizeSavedService(self, service: dict) -> Optional[dict[str,str]]:
+    def normalizeSavedService(self, service: dict) -> dict[str,str] | None:
         if not isinstance(service, dict):
             return None
 
@@ -250,7 +250,7 @@ class SimpleWCSDialog(BASE, GENERATED_CLASS):
 
         self.refreshSavedServicesCombo(selectLastService=True)
 
-    def persistSavedServices(self, selectedIndex: Optional[int] = None) -> None:
+    def persistSavedServices(self, selectedIndex: int | None = None) -> None:
         self.settings.setValue(SETTINGS_SAVED_SERVICES, json.dumps(self.savedServices))
 
         if selectedIndex is None:
@@ -261,7 +261,7 @@ class SimpleWCSDialog(BASE, GENERATED_CLASS):
             self.settings.remove(SETTINGS_LAST_SERVICE)
 
     def refreshSavedServicesCombo(self,
-                                  selectedIndex: Optional[int] = None,
+                                  selectedIndex: int | None = None,
                                   selectLastService: bool = False) -> None:
         currentLabel = None
         if selectLastService:

--- a/simplewcs_dialog.py
+++ b/simplewcs_dialog.py
@@ -141,9 +141,7 @@ class SimpleWCSDialog(BASE, GENERATED_CLASS):
         Sets up the QGIS QgsAuthSettingsWidget, used for managing authentications.
         """
         authcfg = self.get_auth_configID()
-        # TODO add parent for QgsAuthSettingsWidget to simplewcs_dialog_base.ui to ensure a better look
-        self.auth_gui = QgsAuthSettingsWidget(self.tabUrl, configId = authcfg, dataprovider = 'wcs')
-        self.auth_gui.move(20,320) 
+        self.auth_gui = QgsAuthSettingsWidget(self.serviceAuth, configId = authcfg, dataprovider = 'wcs')
         self.auth_gui.removeBasicSettings()
 
     def get_auth_configID(self, service_index: int | None = None) -> str:

--- a/simplewcs_dialog.py
+++ b/simplewcs_dialog.py
@@ -31,9 +31,9 @@ from qgis.core import (QgsApplication,
                        Qgis,
                        QgsTask,
                        QgsRasterLayer,
-                       QgsRectangle,
-                       QgsRasterLayer,)
-from qgis.gui import QgsMessageBar
+                       QgsRectangle)
+from qgis.gui import (QgsMessageBar,
+                      QgsAuthSettingsWidget)
 from qgis.utils import iface
 
 from qgis.PyQt import uic
@@ -123,7 +123,6 @@ class SimpleWCSDialog(BASE, GENERATED_CLASS):
         self.messageBar.hide()
 
         self.setupUrlTab()
-
         self.setupGetCoverageTab()
 
     def setupUrlTab(self) -> None:
@@ -133,8 +132,34 @@ class SimpleWCSDialog(BASE, GENERATED_CLASS):
         """
         self.cbVersion.addItems(self.acceptedWcsVersions)
         self.cbVersion.setCurrentIndex(1)
+        self.setupAuthGui()
         self.loadSavedServices()
         self.updateUrlManagerButtons()
+
+    def setupAuthGui(self) -> None:
+        """
+        Sets up the QGIS QgsAuthSettingsWidget, used for managing authentications.
+        """
+        authcfg = self.get_auth_configID()
+        # TODO add parent for QgsAuthSettingsWidget to simplewcs_dialog_base.ui to ensure a better look
+        self.auth_gui = QgsAuthSettingsWidget(self.tabUrl, configId = authcfg, dataprovider = 'wcs')
+        self.auth_gui.move(20,320) 
+        self.auth_gui.removeBasicSettings()
+
+    def get_auth_configID(self, service_index: int | None = None) -> str:
+        """returns the auth configID of the service with the given index. If none is given,
+        the configID of the currently selected service is returned.
+
+        Args:
+            service_index (int | None, optional): Index of the saved Service configuration. Defaults to None.
+
+        Returns:
+            str: configID of the authentication cofiguration of the QGIS Authentication Framework.
+        """
+        if not service_index:
+            service_index = self.getSelectedSavedServiceIndex()
+        authcfg = self.savedServices[service_index].get('authcfg','') if isinstance(service_index, int) else ''
+        return authcfg
 
     def setupGetCoverageTab(self) -> None:
         """
@@ -187,18 +212,19 @@ class SimpleWCSDialog(BASE, GENERATED_CLASS):
     def getSelectedSavedServiceIndex(self) -> Optional[int]:
         return self.cbSavedServices.currentData()
 
-    def normalizeSavedService(self, service: dict) -> Optional[dict]:
+    def normalizeSavedService(self, service: dict) -> Optional[dict[str,str]]:
         if not isinstance(service, dict):
             return None
 
         name = str(service.get('name', '')).strip()
         url = str(service.get('url', '')).strip()
         version = str(service.get('version', '')).strip()
+        authcfg = str(service.get('authcfg', '')).strip()
 
         if not url or version not in self.acceptedWcsVersions:
             return None
 
-        return {'name': name, 'url': url, 'version': version}
+        return {'name': name, 'url': url, 'version': version, 'authcfg': authcfg}
 
     def getSavedServiceIdentity(self, service: dict) -> Tuple[str, str]:
         return service['url'], service['version']
@@ -271,6 +297,7 @@ class SimpleWCSDialog(BASE, GENERATED_CLASS):
         self.leServiceName.setText(service.get('name', ''))
         self.leBaseUrl.setText(service['url'])
         versionIndex = self.cbVersion.findText(service['version'])
+        self.auth_gui.setConfigId(service.get('authcfg',''))
         if versionIndex >= 0:
             self.cbVersion.setCurrentIndex(versionIndex)
         self.persistSavedServices(selectedIndex=index)
@@ -295,6 +322,7 @@ class SimpleWCSDialog(BASE, GENERATED_CLASS):
         self.cbVersion.setCurrentIndex(1)
         self.updateUrlManagerButtons()
         self.leServiceName.setFocus()
+        self.auth_gui.setConfigId('')
 
     def saveCurrentService(self) -> None:
         serviceName = self.leServiceName.text().strip()
@@ -308,7 +336,8 @@ class SimpleWCSDialog(BASE, GENERATED_CLASS):
         service = {
             'name': serviceName,
             'url': baseUrl,
-            'version': self.cbVersion.currentText()
+            'version': self.cbVersion.currentText(),
+            'authcfg': self.auth_gui.configId()
         }
         selectedIndex = self.getSelectedSavedServiceIndex()
         serviceIdentity = self.getSavedServiceIdentity(service)
@@ -719,7 +748,7 @@ class SimpleWCSDialog(BASE, GENERATED_CLASS):
         """
 
         capabilitiesRequest = self.buildCapabilitiesRequest(version=version, baseUrl=baseUrl)
-        capabilitiesStr = sendRequest(request=capabilitiesRequest)
+        capabilitiesStr = sendRequest(request=capabilitiesRequest, authcfg = self.auth_gui.configId())
         try:
             root = ET.fromstring(capabilitiesStr) # nosec
             capabilitiesXmlMainTag = root.tag
@@ -751,7 +780,7 @@ class SimpleWCSDialog(BASE, GENERATED_CLASS):
             DescribeCoverageException, if any error occurs and the response is not a descrive coverage document
         """
         coverageRequest = self.buildDescribeCoverageRequest(covIds, version)
-        coverageStr = sendRequest(request=coverageRequest)
+        coverageStr = sendRequest(request=coverageRequest, authcfg = self.auth_gui.configId())
         try:
             root = ET.fromstring(coverageStr) # nosec
             coverageXmlMainTag = root.tag
@@ -885,6 +914,7 @@ class SimpleWCSDialog(BASE, GENERATED_CLASS):
 
         try:
             url, covId = self.getCovQueryStr()
+            authcfg = self.auth_gui.configId()
         except ValueError as e:
             self.logWarnMessage(str(e))
             return
@@ -896,6 +926,7 @@ class SimpleWCSDialog(BASE, GENERATED_CLASS):
             getCoverage,
             url,
             covId,
+            authcfg,
             on_finished=self.addRLayer,
             flags=QgsTask.Flag.CanCancel
         )
@@ -1115,12 +1146,12 @@ class SimpleWCSDialog(BASE, GENERATED_CLASS):
         self.messageBar.pushMessage(msg, level=level, duration=duration)
 
 
-def getCoverage(task, urlGetCoverage: str, covId: str) -> dict:
+def getCoverage(task, urlGetCoverage: str, covId: str, authcfg: str = '') -> dict:
     """Requests get coverage using QgsNetworkAccessManager"""
     logInfoMessage('Requested URL: ' + urlGetCoverage)
     try:
         networkManager = QgsNetworkAccessManager()
-        resultGetCoverage = networkManager.blockingGet(QNetworkRequest(QUrl(urlGetCoverage)))
+        resultGetCoverage = networkManager.blockingGet(QNetworkRequest(QUrl(urlGetCoverage)), authCfg = authcfg)
         replyContent = resultGetCoverage.content()
     except HTTPError as e:
         logWarnMessage(str(e))
@@ -1142,10 +1173,10 @@ def getCoverage(task, urlGetCoverage: str, covId: str) -> dict:
         return {'file': replyContent, 'coverage': covId}
 
 
-def sendRequest(request: str) -> str:
+def sendRequest(request: str, authcfg: str = '') -> str:
     networkManager = QgsNetworkAccessManager.instance()
     request = QNetworkRequest(QUrl(request))
-    reply = networkManager.blockingGet(request)
+    reply = networkManager.blockingGet(request, authCfg = authcfg)
     replyContent = reply.content()
     reply = bytes(replyContent).decode()
     return reply

--- a/simplewcs_dialog_base.ui
+++ b/simplewcs_dialog_base.ui
@@ -216,7 +216,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QWidget" name="serviceAuth" native="true">
+           <widget class="QgsAuthSettingsWidget" name="auth_gui" native="true">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
               <horstretch>0</horstretch>
@@ -240,7 +240,7 @@
           <enum>Qt::Vertical</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Minimum</enum>
+          <enum>QSizePolicy::Expanding</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -719,6 +719,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsAuthSettingsWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsauthsettingswidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/simplewcs_dialog_base.ui
+++ b/simplewcs_dialog_base.ui
@@ -39,171 +39,213 @@
        <string>URL</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_2">
-        <item>
-         <widget class="QGroupBox" name="gbSavedServices">
-          <property name="title">
-           <string>Saved Services</string>
-          </property>
-          <layout class="QVBoxLayout" name="verticalLayout_savedServices">
-           <item>
-            <widget class="QComboBox" name="cbSavedServices"/>
-           </item>
-           <item>
-            <widget class="QWidget" name="wgSavedServiceActions" native="true">
-             <layout class="QHBoxLayout" name="horizontalLayout_3">
-              <property name="leftMargin">
-               <number>0</number>
-              </property>
-              <property name="topMargin">
-               <number>0</number>
-              </property>
-              <property name="rightMargin">
-               <number>0</number>
-              </property>
-              <property name="bottomMargin">
-               <number>0</number>
-              </property>
-              <item>
-               <widget class="QPushButton" name="btnNewService">
-                <property name="text">
-                 <string>New</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QPushButton" name="btnSaveService">
-                <property name="text">
-                 <string>Save</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QPushButton" name="btnDeleteService">
-                <property name="text">
-                 <string>Delete</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <widget class="QWidget" name="wgSavedServiceFileActions" native="true">
-             <layout class="QHBoxLayout" name="horizontalLayout_4">
-              <property name="leftMargin">
-               <number>0</number>
-              </property>
-              <property name="topMargin">
-               <number>0</number>
-              </property>
-              <property name="rightMargin">
-               <number>0</number>
-              </property>
-              <property name="bottomMargin">
-               <number>0</number>
-              </property>
-              <item>
-               <widget class="QPushButton" name="btnImportServices">
-                <property name="text">
-                 <string>Import</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QPushButton" name="btnExportServices">
-                <property name="text">
-                 <string>Export</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="gbServiceDetails">
-          <property name="title">
-           <string>Service Details</string>
-          </property>
-          <layout class="QVBoxLayout" name="verticalLayout_serviceDetails">
-           <item>
-            <widget class="QLabel" name="lblServiceName">
-             <property name="font">
-              <font>
-               <pointsize>8</pointsize>
-               <bold>true</bold>
-              </font>
+       <item>
+        <widget class="QGroupBox" name="gbSavedServices">
+         <property name="title">
+          <string>Saved Services</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_savedServices">
+          <item>
+           <widget class="QComboBox" name="cbSavedServices"/>
+          </item>
+          <item>
+           <widget class="QWidget" name="wgSavedServiceActions" native="true">
+            <layout class="QHBoxLayout" name="horizontalLayout_3">
+             <property name="leftMargin">
+              <number>0</number>
              </property>
-             <property name="text">
-              <string>Service Name:</string>
+             <property name="topMargin">
+              <number>0</number>
              </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLineEdit" name="leServiceName">
-             <property name="placeholderText">
-              <string>e.g. Brandenburg DGM</string>
+             <property name="rightMargin">
+              <number>0</number>
              </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="lblUrl">
-             <property name="font">
-              <font>
-               <pointsize>8</pointsize>
-               <bold>true</bold>
-              </font>
+             <property name="bottomMargin">
+              <number>0</number>
              </property>
-             <property name="text">
-              <string>Enter WCS 2.X URL:</string>
+             <item>
+              <widget class="QPushButton" name="btnNewService">
+               <property name="text">
+                <string>New</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="btnSaveService">
+               <property name="text">
+                <string>Save</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="btnDeleteService">
+               <property name="text">
+                <string>Delete</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QWidget" name="wgSavedServiceFileActions" native="true">
+            <layout class="QHBoxLayout" name="horizontalLayout_4">
+             <property name="leftMargin">
+              <number>0</number>
              </property>
-             <property name="scaledContents">
-              <bool>false</bool>
+             <property name="topMargin">
+              <number>0</number>
              </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLineEdit" name="leBaseUrl">
-             <property name="inputMask">
-              <string/>
+             <property name="rightMargin">
+              <number>0</number>
              </property>
-             <property name="text">
-              <string/>
+             <property name="bottomMargin">
+              <number>0</number>
              </property>
-             <property name="placeholderText">
-              <string>e.g. https://example.org/wcs?</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="lblVersionDesc">
-             <property name="font">
-              <font>
-               <bold>true</bold>
-              </font>
-             </property>
-             <property name="text">
-              <string>Choose Version</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QComboBox" name="cbVersion"/>
-           </item>
-          </layout>
-         </widget>
-        </item>
+             <item>
+              <widget class="QPushButton" name="btnImportServices">
+               <property name="text">
+                <string>Import</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="btnExportServices">
+               <property name="text">
+                <string>Export</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="gbServiceDetails">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="title">
+          <string>Service Details</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_serviceDetails">
+          <item>
+           <widget class="QLabel" name="lblServiceName">
+            <property name="font">
+             <font>
+              <pointsize>8</pointsize>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Service Name:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="leServiceName">
+            <property name="placeholderText">
+             <string>e.g. Brandenburg DGM</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="lblUrl">
+            <property name="font">
+             <font>
+              <pointsize>8</pointsize>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Enter WCS 2.X URL:</string>
+            </property>
+            <property name="scaledContents">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="leBaseUrl">
+            <property name="inputMask">
+             <string/>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+            <property name="placeholderText">
+             <string>e.g. https://example.org/wcs?</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="lblVersionDesc">
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Choose Version</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="cbVersion"/>
+          </item>
+          <item>
+           <widget class="QLabel" name="lblServiceAuth">
+            <property name="font">
+             <font>
+              <pointsize>8</pointsize>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Service Authentication:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QWidget" name="serviceAuth" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="baseSize">
+             <size>
+              <width>80</width>
+              <height>200</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
        <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Minimum</enum>
+         </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>40</height>
+           <height>30</height>
           </size>
          </property>
         </spacer>
@@ -220,6 +262,7 @@
          <property name="font">
           <font>
            <pointsize>7</pointsize>
+           <weight>50</weight>
            <bold>false</bold>
           </font>
          </property>
@@ -242,6 +285,7 @@
         <widget class="QLabel" name="lblTitleDesc">
          <property name="font">
           <font>
+           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -254,6 +298,7 @@
         <widget class="QLabel" name="lblTitle">
          <property name="font">
           <font>
+           <weight>50</weight>
            <bold>false</bold>
           </font>
          </property>
@@ -275,6 +320,7 @@
         <widget class="QLabel" name="lblVersionDesc_2">
          <property name="font">
           <font>
+           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -287,6 +333,7 @@
         <widget class="QLabel" name="lblVersion">
          <property name="font">
           <font>
+           <weight>50</weight>
            <bold>false</bold>
           </font>
          </property>
@@ -308,6 +355,7 @@
         <widget class="QLabel" name="lblCoverageDesc">
          <property name="font">
           <font>
+           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -323,6 +371,7 @@
         <widget class="QLabel" name="lblFormatDesc">
          <property name="font">
           <font>
+           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -338,6 +387,7 @@
         <widget class="QLabel" name="lblCRSDesc">
          <property name="font">
           <font>
+           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -353,6 +403,7 @@
         <widget class="QCheckBox" name="cbUseSubset">
          <property name="font">
           <font>
+           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -383,6 +434,7 @@
            <widget class="QLabel" name="label">
             <property name="font">
              <font>
+              <weight>75</weight>
               <bold>true</bold>
              </font>
             </property>
@@ -423,6 +475,7 @@
               <widget class="QLabel" name="lblExtentDesc">
                <property name="font">
                 <font>
+                 <weight>75</weight>
                  <bold>true</bold>
                 </font>
                </property>
@@ -555,6 +608,7 @@
         <widget class="QLabel" name="lblProviderDesc">
          <property name="font">
           <font>
+           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -567,6 +621,7 @@
         <widget class="QLabel" name="lblProvider">
          <property name="font">
           <font>
+           <weight>50</weight>
            <bold>false</bold>
           </font>
          </property>
@@ -585,6 +640,7 @@
         <widget class="QLabel" name="lblFeesDesc">
          <property name="font">
           <font>
+           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -597,6 +653,7 @@
         <widget class="QLabel" name="lblFees">
          <property name="font">
           <font>
+           <weight>50</weight>
            <bold>false</bold>
           </font>
          </property>
@@ -615,6 +672,7 @@
         <widget class="QLabel" name="lblConstraintsDesc">
          <property name="font">
           <font>
+           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -627,6 +685,7 @@
         <widget class="QLabel" name="lblConstraints">
          <property name="font">
           <font>
+           <weight>50</weight>
            <bold>false</bold>
           </font>
          </property>


### PR DESCRIPTION
Some WCS require authentication. To enable the use of Services the QGIS Authentication Framework is applyed. 
Add the QgsAuthSettingsWidget to the GUI and the configID to Requests of the QgsNetworkManager.
The configID of a Service saves like the rest of a Service configuration.